### PR TITLE
Fixed minor docs section detail

### DIFF
--- a/docs/configuration/include-and-exclude.md
+++ b/docs/configuration/include-and-exclude.md
@@ -26,7 +26,7 @@ These use-cases are solved by the `include` and `exclude` rules.
 
 
 Let's start with a simple example. We want to create a set of email replies
-and only enable when when inside Chrome or Firefox.
+and only enable them when inside Chrome or Firefox.
 
 We start by defining the snippets inside the `match/_email.yml` file:
 


### PR DESCRIPTION
While reading through [the inclusion and exclusion rules config feature docs page](https://espanso.org/docs/configuration/include-and-exclude/), I observed something that could probably be improved.

Under the "Typical use-case for include rules" heading the the passage read:
> "and only enable when when inside Chrome"

That's confusing and likely a minor and reasonable editing oversight. Using a spelling and grammar validation feature in a modern text editor application like Google Docs, suggests the following improvement, which is the reasonable sentence the documentation editor likely intended:

> "and only enable them when inside Chrome"

I went ahead and fixed it already. Feel free to ignore this if this has already been corrected in a staging branch or if it's irrelevant.

Cheers!
Arty